### PR TITLE
 Add Cnpj digit calculator

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,18 @@ make test
 
 Read the full documentation at [https://godoc.org/github.com/brazanation/go-documents](https://godoc.org/github.com/brazanation/go-documents).
 
+### CNPJ (cadastro nacional da pessoa jurídica)
+
+Company Identification or National Register of Legal Entities
+
+```go
+doc, err := brdocs.NewCnpj("99999090910270")
+if err != nil {
+    panic(err)
+}
+println(doc.String()) // prints 99999090910270
+println(doc.Format()) // prints 99.999.090/9102-70
+```
 
 ## License
 

--- a/cnpj.go
+++ b/cnpj.go
@@ -1,0 +1,43 @@
+package brdocs
+
+import (
+	"fmt"
+	"github.com/brazanation/go-documents/internal"
+	"github.com/brazanation/go-documents/internal/calculator"
+)
+
+const CnpjType internal.DocumentType = "Cnpj"
+
+const (
+	cnpjLength         int    = 14
+	cnpjNumberOfDigits int    = 2
+	cnpjValidatorRegex string = `^([\d]{2})([\d]{3})([\d]{3})([\d]{4})([\d]{2})$`
+	cnpjFormatterRegex string = "$1.$2.$3/$4-$5"
+)
+
+type Cnpj struct {
+}
+
+// NewCnpj is the constructor of Cnpj
+func NewCnpj(number string) (internal.Document, error) {
+	d, err := internal.NewDocument(
+		CnpjType,
+		number,
+		cnpjLength,
+		cnpjNumberOfDigits,
+		cnpjFormatterRegex,
+		cnpjValidatorRegex,
+		Cnpj{},
+	)
+	return d, err
+}
+
+func (cnpj Cnpj) CalculateDigit(base string) string {
+	c := calculator.NewModule11(base)
+	c.UseComplementaryInsteadOfModule()
+	c.ReplaceWhen(0, 10, 11)
+	firstDigit := c.Calculate()
+	c.AddDigit(firstDigit)
+	secondDigit := c.Calculate()
+	return fmt.Sprintf("%d%d", firstDigit, secondDigit)
+}

--- a/cnpj_test.go
+++ b/cnpj_test.go
@@ -1,0 +1,41 @@
+package brdocs_test
+
+import (
+	"github.com/brazanation/go-documents"
+	"github.com/brazanation/go-documents/internal/test"
+	"testing"
+)
+
+func TestCnpjShouldBeValid(t *testing.T) {
+	cnpj, err := brdocs.NewCnpj("99999090910270")
+	internal_test.AssertValidDocument(t, cnpj, err)
+}
+
+func TestDocumentShouldBeSameType(t *testing.T) {
+	cnpj, _ := brdocs.NewCnpj("99999090910270")
+	internal_test.AssertDocumentType(t, cnpj, brdocs.CnpjType)
+}
+
+func TestCnpjShouldBeFormatted(t *testing.T) {
+	cnpj, err := brdocs.NewCnpj("99999090910270")
+	internal_test.AssertValidDocument(t, cnpj, err)
+	internal_test.AssertDocumentFormatted(t, cnpj, "99.999.090/9102-70")
+}
+
+func TestCnpjShouldReturnErrorForRepeatedNumber(t *testing.T) {
+	number := "11111111111111"
+	_, err := brdocs.NewCnpj(number)
+	internal_test.AssertNotValidDocument(t, number, err, "Cnpj(11111111111111) is invalid")
+}
+
+func TestCnpjShouldReturnErrorForInvalidNumber(t *testing.T) {
+	number := "00111222100099"
+	_, err := brdocs.NewCnpj(number)
+	internal_test.AssertNotValidDocument(t, number, err, "Cnpj(00111222100099) is invalid")
+}
+
+func TestCnpjShouldReturnErrorForEmptyNumber(t *testing.T) {
+	number := ``
+	_, err := brdocs.NewCnpj(number)
+	internal_test.AssertNotValidDocument(t, number, err, "Cnpj must not be empty")
+}


### PR DESCRIPTION
It is used to calculate if company identification is a valid number.